### PR TITLE
pnm.lisp should have make-8-bit-rgb-image for ppm binary stream

### DIFF
--- a/pnm.lisp
+++ b/pnm.lisp
@@ -291,7 +291,7 @@
         (height (parse-integer (read-number stream)))
         (maxval (parse-integer (read-number stream))))
     (if (< maxval 256)
-        (let ((img (make-8-bit-gray-image height width)))    
+        (let ((img (make-8-bit-rgb-image height width)))    
           (loop for i below height
              do 
              (loop for j below width


### PR DESCRIPTION
%read-ppm-binary-stream in pnm.lisp should have make-8-bit-rgb-image not make-8-bit-grey-image

thanks for writing this great package!
