### PR TITLE
Treat clasp like clisp and abcl

### DIFF
--- a/opticl.asd
+++ b/opticl.asd
@@ -9,8 +9,8 @@
   :depends-on (alexandria
                retrospectiff
                zpng
-               #-(or clisp abcl) pngload
-               #+(or clisp abcl) png-read
+               #-(or clisp abcl clasp) pngload
+               #+(or clisp abcl clasp) png-read
                cl-jpeg
                skippy
                opticl-core

--- a/png.lisp
+++ b/png.lisp
@@ -68,7 +68,7 @@
     (write-png-stream stream image)
     (truename pathname)))
 
-#+(or clisp abcl)
+#+(or clisp abcl clasp)
 (defun read-png-stream (stream)
   (let* ((png (png-read:read-png-datastream stream))
 	 (colour-type (png-read:colour-type png))
@@ -226,7 +226,7 @@
 	      (setf (pixel img i j)
 		    (funcall get-pixel-fn i j)))))))))
 
-#+(or clisp abcl)
+#+(or clisp abcl clasp)
 (defun read-png-file (pathname)
   (with-open-file (stream pathname :direction :input :element-type '(unsigned-byte 8))
     (read-png-stream stream)))

--- a/pngload.lisp
+++ b/pngload.lisp
@@ -3,11 +3,11 @@
 
 (in-package :opticl)
 
-#-(or clisp abcl)
+#-(or clisp abcl clasp)
 (defun read-png-stream (stream)
   (pngload:data (pngload:load-stream stream)))
 
-#-(or clisp abcl)
+#-(or clisp abcl clasp)
 (defun read-png-file (pathname)
   (with-open-file (stream pathname
                           :direction :input


### PR DESCRIPTION
Since otherwise the dependency static-vectors is needed, which doesn't work on clasp. This is enough to make mcclim happy on clasp