### PR TITLE
Fix jpeg.lisp compilation

### DIFF
--- a/jpeg.lisp
+++ b/jpeg.lisp
@@ -3,9 +3,11 @@
 
 (in-package :opticl)
 
-(defconstant +ncomp-gray+ 1)
-(defconstant +ncomp-rgb+ 3)
-(defconstant +ncomp-cmyk+ 4)
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (defconstant +ncomp-gray+ 1)
+  (defconstant +ncomp-rgb+ 3)
+  (defconstant +ncomp-cmyk+ 4))
+
 
 (defparameter *rgb-sampling* '((1 1)(1 1)(1 1)))
 (defparameter *rgb-q-tabs* (vector jpeg::+q-luminance-hi+
@@ -147,5 +149,3 @@
                           :if-exists :supersede)
     (write-jpeg-stream stream image)
     pathname))
-
-


### PR DESCRIPTION
In the `#.` expansion in read-jpeg-stream, we need these variables to be ready at compile at time. Happens on Lispworks. SBCL seems to be not complaining about this.