### PR TITLE
Improve color table handling for GIF images

### DIFF
--- a/gif.lisp
+++ b/gif.lisp
@@ -1,4 +1,3 @@
-
 ;;; Copyright (c) 2011 Cyrus Harmon, All rights reserved.
 ;;; See COPYRIGHT file for details.
 
@@ -7,24 +6,28 @@
 ;;; Note: a GIF can contain multiple images. We're going to ignore
 ;;; this little detail and just return one image for the moment.
 
-(defun skippy-image-to-8-bit-rgb-image (skippy-image color-table)
+(defun skippy-image-to-8-bit-rgb-image (skippy-image global-color-table)
   (with-accessors ((height skippy:height)
                    (width skippy:width)
-                   (image-data skippy:image-data))
+                   (image-data skippy:image-data)
+                   (image-color-table skippy:color-table))
       skippy-image
-    (let ((new-image (make-8-bit-rgb-image height width)))
+    (let ((color-table (or image-color-table
+                           global-color-table
+                           (error "~@<Could not find color table for image ~A.~@:>"
+                                  skippy-image)))
+          (new-image   (make-8-bit-rgb-image height width)))
       (set-pixels (i j) new-image
         (skippy:color-rgb
-         (skippy:color-table-entry color-table
-                                   (skippy:pixel-ref skippy-image j i))))
+         (skippy:color-table-entry color-table index)))
       new-image)))
 
 (defun read-gif-stream (stream)
-  (let ((data-stream (skippy:read-data-stream stream)))
-    (let ((color-table (skippy:color-table data-stream)))
-      (values-list 
-       (loop for image across (skippy:images data-stream)
-          collect (skippy-image-to-8-bit-rgb-image image color-table))))))
+  (let* ((data-stream (skippy:read-data-stream stream))
+         (color-table (skippy:color-table data-stream)))
+    (values-list
+     (loop for image across (skippy:images data-stream)
+           collect (skippy-image-to-8-bit-rgb-image image color-table)))))
 
 (defun read-gif-file (pathname)
   (with-open-file (stream pathname :direction :input :element-type '(unsigned-byte 8))
@@ -38,7 +41,7 @@
              do (loop for b below b-levels
                    do
                      (setf (aref array (+ (* r g-levels b-levels)
-                                          (* g b-levels) 
+                                          (* g b-levels)
                                           b))
                            (list (floor (* r (/ max-val (1- r-levels))))
                                  (floor (* g (/ max-val (1- g-levels))))
@@ -80,7 +83,7 @@
            (gif-image (8-bit-rgb-image-to-skippy-image image
                                                        (skippy:color-table data-stream))))
       (skippy:add-image gif-image data-stream)
-      (skippy:write-data-stream data-stream stream)))) 
+      (skippy:write-data-stream data-stream stream))))
 
 (defun write-gif-file (pathname image)
   (with-open-file (stream pathname :direction :output


### PR DESCRIPTION
* Add alpha channel for images with transparency index

* When available, use image-local color table